### PR TITLE
doc: add qt5-graphicaleffects to Arch packages

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -112,7 +112,7 @@ if all packages can be installed.
 
 This command should provide required packages for Arch Linux installation:
 
-`sudo pacman -S --needed python python-pillow python-numpy python-pygments cython libepoxy ttf-dejavu freetype2 fontconfig harfbuzz cmake sdl2 sdl2_image opusfile opus-tools python-pylint qt5-declarative qt5-quickcontrols`
+`sudo pacman -S --needed python python-pillow python-numpy python-pygments cython libepoxy ttf-dejavu freetype2 fontconfig harfbuzz cmake sdl2 sdl2_image opusfile opus-tools python-pylint qt5-declarative qt5-quickcontrols qt5-graphicaleffects`
 
 If you don't have a compiler installed, you can select between these commands to install it:
  - `sudo pacman -S --needed gcc`


### PR DESCRIPTION
I'm not sure if the other distros also need this and I can't test it, but without this package the game won't start properly on Arch Linux.
