### PR TITLE
Provide missing GL_DEBUG definitions (fix compile on Mac)

### DIFF
--- a/libopenage/gamestate/resource.cpp
+++ b/libopenage/gamestate/resource.cpp
@@ -1,5 +1,6 @@
 // Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
+#include <string>
 #include <cmath>
 
 #include "resource.h"

--- a/libopenage/gui/guisys/CMakeLists.txt
+++ b/libopenage/gui/guisys/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND QT_SDL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/private/game_logic_caller.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_application_impl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_callback.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_ctx_setup.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_dedicated_thread.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_engine_impl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_event_queue_impl.cpp

--- a/libopenage/gui/guisys/CMakeLists.txt
+++ b/libopenage/gui/guisys/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND QT_SDL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_input_impl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_renderer_impl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_subtree_impl.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/private/opengl_debug_logger.cpp
 )
 
 list(APPEND QT_SDL_SOURCES

--- a/libopenage/gui/guisys/CMakeLists.txt
+++ b/libopenage/gui/guisys/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND QT_SDL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_image_provider_impl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_input_impl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_renderer_impl.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_rendering_setup_routines.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/gui_subtree_impl.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/private/opengl_debug_logger.cpp
 )

--- a/libopenage/gui/guisys/private/gui_ctx_setup.cpp
+++ b/libopenage/gui/guisys/private/gui_ctx_setup.cpp
@@ -1,0 +1,105 @@
+// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+#include "gui_ctx_setup.h"
+
+#include <cassert>
+
+#include <QOpenGLDebugLogger>
+
+#include "platforms/context_extraction.h"
+#include "opengl_debug_logger.h"
+
+namespace qtsdl {
+
+CtxExtractionException::CtxExtractionException(const std::string &what_arg)
+	:
+	std::runtime_error{what_arg} {
+}
+
+QOpenGLContext* CtxExtractionMode::get_ctx() {
+	return &this->ctx;
+}
+
+GuiUniqueRenderingContext::GuiUniqueRenderingContext(SDL_Window *window)
+	:
+	CtxExtractionMode{} {
+
+	QVariant handle;
+	WId id;
+
+	std::tie(handle, id) = extract_native_context(window);
+
+	if (handle.isValid()) {
+		// pass the SDL opengl context so qt can use it
+		this->ctx.setNativeHandle(handle);
+		this->ctx.create();
+		assert(this->ctx.isValid());
+
+		// reuse the sdl window
+		QWindow *w = QWindow::fromWinId(id);
+		w->setSurfaceType(QSurface::OpenGLSurface);
+
+		if (this->ctx.makeCurrent(w)) {
+			return;
+		}
+	}
+
+	throw CtxExtractionException("adding GUI to the main rendering context failed");
+}
+
+void GuiUniqueRenderingContext::pre_render() {
+}
+
+void GuiUniqueRenderingContext::post_render() {
+}
+
+GuiSeparateRenderingContext::GuiSeparateRenderingContext(SDL_Window *window)
+	:
+	CtxExtractionMode{} {
+
+	QVariant handle;
+
+	std::tie(handle, this->make_current_back) = extract_native_context_and_switchback_func(window);
+
+	if (handle.isValid()) {
+		this->main_ctx.setNativeHandle(handle);
+		this->main_ctx.create();
+		assert(this->main_ctx.isValid());
+
+		auto context_debug_parameters = get_current_opengl_debug_parameters(this->main_ctx);
+
+		this->ctx.setFormat(this->main_ctx.format());
+		this->ctx.setShareContext(&this->main_ctx);
+		this->ctx.create();
+		assert(this->ctx.isValid());
+		assert(!(this->main_ctx.format().options() ^ this->ctx.format().options()).testFlag(QSurfaceFormat::DebugContext));
+
+		this->offscreen_surface.setFormat(this->ctx.format());
+		this->offscreen_surface.create();
+
+		this->pre_render();
+		apply_opengl_debug_parameters(context_debug_parameters, this->ctx);
+		this->post_render();
+	} else {
+		throw CtxExtractionException("creating separate context for GUI failed");
+	}
+}
+
+GuiSeparateRenderingContext::~GuiSeparateRenderingContext() {
+	this->pre_render();
+	this->ctx_logger.reset();
+	this->post_render();
+}
+
+void GuiSeparateRenderingContext::pre_render() {
+	if (!this->ctx.makeCurrent(&this->offscreen_surface)) {
+		assert(false);
+		return;
+	}
+}
+
+void GuiSeparateRenderingContext::post_render() {
+	this->make_current_back();
+}
+
+} // namespace qtsdl

--- a/libopenage/gui/guisys/private/gui_ctx_setup.h
+++ b/libopenage/gui/guisys/private/gui_ctx_setup.h
@@ -1,0 +1,94 @@
+// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <stdexcept>
+#include <memory>
+#include <functional>
+
+#include <QOpenGLContext>
+#include <QOffscreenSurface>
+
+struct SDL_Window;
+
+QT_FORWARD_DECLARE_CLASS(QOpenGLDebugLogger)
+
+namespace qtsdl {
+
+class CtxExtractionException : public std::runtime_error {
+public:
+	explicit CtxExtractionException(const std::string &what_arg);
+};
+
+/**
+ * Abstract base for the method of getting a Qt-usable context.
+ */
+class CtxExtractionMode {
+public:
+	virtual ~CtxExtractionMode() {
+	}
+
+	/**
+	 * @return context that can be used by Qt
+	 */
+	QOpenGLContext* get_ctx();
+
+	/**
+	 * Function that must be called before rendering the GUI.
+	 */
+	virtual void pre_render() = 0;
+
+	/**
+	 * Function that must be called after rendering the GUI.
+	 */
+	virtual void post_render() = 0;
+
+protected:
+	QOpenGLContext ctx;
+};
+
+/**
+ * Use the same context to render the GUI.
+ */
+class GuiUniqueRenderingContext : public CtxExtractionMode {
+public:
+	explicit GuiUniqueRenderingContext(SDL_Window *window);
+
+	virtual void pre_render() override;
+	virtual void post_render() override;
+};
+
+/**
+ * Create a separate context to render the GUI, make it shared with the main context.
+ */
+class GuiSeparateRenderingContext : public CtxExtractionMode {
+public:
+	explicit GuiSeparateRenderingContext(SDL_Window *window);
+	virtual ~GuiSeparateRenderingContext();
+
+	virtual void pre_render() override;
+	virtual void post_render() override;
+
+private:
+	/**
+	 * GL context of the game
+	 */
+	QOpenGLContext main_ctx;
+
+	/**
+	 * GL debug logger of the GL context of the GUI
+	 */
+	std::unique_ptr<QOpenGLDebugLogger> ctx_logger;
+
+	/**
+	 * Function to make the game context current
+	 */
+	std::function<void()> make_current_back;
+
+	/**
+	 * Surface that is needed to make the GUI context current
+	 */
+	QOffscreenSurface offscreen_surface;
+};
+
+} // namespace qtsdl

--- a/libopenage/gui/guisys/private/gui_renderer_impl.h
+++ b/libopenage/gui/guisys/private/gui_renderer_impl.h
@@ -1,9 +1,8 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <memory>
-#include <functional>
 #include <atomic>
 #include <mutex>
 #include <condition_variable>
@@ -14,9 +13,10 @@
 #include <QQuickRenderControl>
 #include <QOffscreenSurface>
 
+#include "gui_rendering_setup_routines.h"
+
 struct SDL_Window;
 
-QT_FORWARD_DECLARE_CLASS(QOpenGLContext)
 QT_FORWARD_DECLARE_CLASS(QOpenGLFramebufferObject)
 
 namespace qtsdl {
@@ -111,9 +111,10 @@ private:
 	void reinit_fbo_if_needed();
 
 	/**
-	 * GL context of the game
+	 * Contains rendering context
+	 * Use GuiRenderingCtxActivator to enable it
 	 */
-	std::unique_ptr<QOpenGLContext> ctx;
+	GuiRenderingSetupRoutines gui_rendering_setup_routines;
 
 	/**
 	 * Contains scene graph of the GUI

--- a/libopenage/gui/guisys/private/gui_rendering_setup_routines.cpp
+++ b/libopenage/gui/guisys/private/gui_rendering_setup_routines.cpp
@@ -1,0 +1,68 @@
+// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+#include "gui_rendering_setup_routines.h"
+
+#include <cassert>
+
+#include <QDebug>
+
+#include "gui_ctx_setup.h"
+
+namespace qtsdl {
+
+GuiRenderingSetupRoutines::GuiRenderingSetupRoutines(SDL_Window *window) {
+	try {
+		this->ctx_extraction_mode = std::make_unique<GuiUniqueRenderingContext>(window);
+	} catch (const CtxExtractionException&) {
+
+		qInfo() << "Falling back to separate render context for GUI";
+
+		try {
+			this->ctx_extraction_mode = std::make_unique<GuiSeparateRenderingContext>(window);
+		} catch (const CtxExtractionException&) {
+			assert(false && "setting up context for GUI failed");
+		}
+	}
+}
+
+GuiRenderingSetupRoutines::~GuiRenderingSetupRoutines() {
+}
+
+QOpenGLContext* GuiRenderingSetupRoutines::get_ctx() {
+	return this->ctx_extraction_mode->get_ctx();
+}
+
+void GuiRenderingSetupRoutines::pre_render() {
+	this->ctx_extraction_mode->pre_render();
+}
+
+void GuiRenderingSetupRoutines::post_render() {
+	this->ctx_extraction_mode->post_render();
+}
+
+GuiRenderingCtxActivator::GuiRenderingCtxActivator(GuiRenderingSetupRoutines &rendering_setup_routines)
+	:
+	rendering_setup_routines{&rendering_setup_routines} {
+
+	this->rendering_setup_routines->pre_render();
+}
+
+GuiRenderingCtxActivator::~GuiRenderingCtxActivator() {
+	if (this->rendering_setup_routines)
+		this->rendering_setup_routines->post_render();
+}
+
+GuiRenderingCtxActivator::GuiRenderingCtxActivator(GuiRenderingCtxActivator&& o)
+	:
+	rendering_setup_routines{o.rendering_setup_routines} {
+
+	o.rendering_setup_routines = nullptr;
+}
+
+GuiRenderingCtxActivator& GuiRenderingCtxActivator::operator=(GuiRenderingCtxActivator&& o) {
+	this->rendering_setup_routines = o.rendering_setup_routines;
+	o.rendering_setup_routines = nullptr;
+	return *this;
+}
+
+} // namespace qtsdl

--- a/libopenage/gui/guisys/private/gui_rendering_setup_routines.h
+++ b/libopenage/gui/guisys/private/gui_rendering_setup_routines.h
@@ -1,0 +1,57 @@
+// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <memory>
+
+#include <QtGlobal>
+
+struct SDL_Window;
+
+QT_FORWARD_DECLARE_CLASS(QOpenGLContext)
+
+namespace qtsdl {
+
+class CtxExtractionMode;
+
+class GuiRenderingCtxActivator;
+
+/**
+ * Returns a GL context usable by Qt classes.
+ * Provides pre- and post-rendering functions to make the context usable for GUI rendering.
+ */
+class GuiRenderingSetupRoutines {
+public:
+	explicit GuiRenderingSetupRoutines(SDL_Window *window);
+	~GuiRenderingSetupRoutines();
+
+	QOpenGLContext* get_ctx();
+
+private:
+	friend class GuiRenderingCtxActivator;
+	void pre_render();
+	void post_render();
+
+	std::unique_ptr<CtxExtractionMode> ctx_extraction_mode;
+};
+
+/**
+ * Prepares the context for rendering the GUI for one frame.
+ * Activator must be destroyed as soon as the GUI has executed its frame render call.
+ */
+class GuiRenderingCtxActivator {
+public:
+	explicit GuiRenderingCtxActivator(GuiRenderingSetupRoutines &rendering_setup_routines);
+	~GuiRenderingCtxActivator();
+
+	GuiRenderingCtxActivator(GuiRenderingCtxActivator&& o);
+	GuiRenderingCtxActivator& operator=(GuiRenderingCtxActivator&& o);
+
+private:
+	GuiRenderingCtxActivator(const GuiRenderingCtxActivator&) = delete;
+	GuiRenderingCtxActivator& operator=(const GuiRenderingCtxActivator&) = delete;
+
+	GuiRenderingSetupRoutines *rendering_setup_routines;
+};
+
+} // namespace qtsdl

--- a/libopenage/gui/guisys/private/opengl_debug_logger.cpp
+++ b/libopenage/gui/guisys/private/opengl_debug_logger.cpp
@@ -1,0 +1,40 @@
+// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+#include "opengl_debug_logger.h"
+
+#include <QOpenGLContext>
+#include <QOpenGLFunctions_4_4_Core>
+
+namespace qtsdl {
+
+gl_debug_parameters get_current_opengl_debug_parameters(const QOpenGLContext &current_source_context)  {
+	gl_debug_parameters params{};
+
+	if (current_source_context.versionFunctions<QOpenGLFunctions_4_4_Core>())
+		if ((params.is_debug = current_source_context.format().options().testFlag(QSurfaceFormat::DebugContext))) {
+			glGetPointerv(GL_DEBUG_CALLBACK_FUNCTION, &params.callback);
+			params.synchronous = glIsEnabled(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+		}
+
+	return params;
+}
+
+void apply_opengl_debug_parameters(gl_debug_parameters params, QOpenGLContext &current_dest_context)  {
+	if (params.is_debug && params.callback) {
+		if (auto functions = current_dest_context.versionFunctions<QOpenGLFunctions_4_4_Core>()) {
+			functions->initializeOpenGLFunctions();
+
+			functions->glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, nullptr, GL_FALSE);
+
+			functions->glDebugMessageControl(GL_DONT_CARE, GL_DEBUG_TYPE_ERROR, GL_DONT_CARE, 0, nullptr, GL_TRUE);
+			functions->glDebugMessageControl(GL_DONT_CARE, GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR, GL_DONT_CARE, 0, nullptr, GL_TRUE);
+
+			functions->glDebugMessageCallback((GLDEBUGPROC)params.callback, nullptr);
+
+			if (params.synchronous)
+				glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+		}
+	}
+}
+
+} // namespace qtsdl

--- a/libopenage/gui/guisys/private/opengl_debug_logger.cpp
+++ b/libopenage/gui/guisys/private/opengl_debug_logger.cpp
@@ -5,6 +5,14 @@
 #include <QOpenGLContext>
 #include <QOpenGLFunctions_4_4_Core>
 
+#ifdef __APPLE__
+// from https://www.khronos.org/registry/OpenGL/api/GL/glext.h
+#define GL_DEBUG_CALLBACK_FUNCTION        0x8244
+#define GL_DEBUG_OUTPUT_SYNCHRONOUS       0x8242
+#define GL_DEBUG_TYPE_ERROR               0x824C
+#define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR  0x824E
+#endif
+
 namespace qtsdl {
 
 gl_debug_parameters get_current_opengl_debug_parameters(const QOpenGLContext &current_source_context)  {

--- a/libopenage/gui/guisys/private/opengl_debug_logger.h
+++ b/libopenage/gui/guisys/private/opengl_debug_logger.h
@@ -1,0 +1,43 @@
+// Copyright 2017-2017 the openage authors. See copying.md for legal info.
+
+#pragma once
+
+#include <QOpenGLFunctions>
+
+QT_FORWARD_DECLARE_CLASS(QOpenGLContext)
+
+namespace qtsdl {
+struct gl_debug_parameters {
+	/**
+	 * True if the GL context is a debug context
+	 */
+	bool is_debug;
+
+	/**
+	 * Function that GL context uses to report debug messages
+	 */
+	GLvoid *callback;
+
+	/**
+	 * True if debug callback calling method is chosen to be synchronous
+	 */
+	bool synchronous;
+};
+
+/**
+ * Get debugging settings of the current GL context
+ *
+ * @param current_source_context current GL context
+ * @return debugging settings
+ */
+gl_debug_parameters get_current_opengl_debug_parameters(const QOpenGLContext &current_source_context);
+
+/**
+ * Create a GL logger in the current GL context
+ *
+ * @param params debugging settings
+ * @param current_dest_context current GL context to which parameters will be applied
+ */
+void apply_opengl_debug_parameters(gl_debug_parameters params, QOpenGLContext &current_dest_context);
+
+}

--- a/libopenage/gui/guisys/private/platforms/context_extraction.h
+++ b/libopenage/gui/guisys/private/platforms/context_extraction.h
@@ -1,8 +1,9 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #pragma once
 
 #include <tuple>
+#include <functional>
 
 #include <QWindow>
 #include <QVariant>
@@ -11,6 +12,14 @@ struct SDL_Window;
 
 namespace qtsdl {
 
+/**
+ * @return current context (or null) and id of the window
+ */
 std::tuple<QVariant, WId> extract_native_context(SDL_Window *window);
+
+/**
+ * @return current context (or null) and function to get it back to the window
+ */
+std::tuple<QVariant, std::function<void()>> extract_native_context_and_switchback_func(SDL_Window *window);
 
 } // namespace qtsdl

--- a/libopenage/gui/guisys/private/platforms/context_extraction_cocoa.mm
+++ b/libopenage/gui/guisys/private/platforms/context_extraction_cocoa.mm
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #include <cassert>
 
@@ -12,6 +12,10 @@
 namespace qtsdl {
 
 std::tuple<QVariant, WId> extract_native_context(SDL_Window *window) {
+	return std::tuple<QVariant, WId>{};
+}
+
+std::tuple<QVariant, std::function<void()>> extract_native_context_and_switchback_func(SDL_Window *window) {
 	assert(window);
 
 	NSOpenGLContext *current_context = [NSOpenGLContext currentContext];
@@ -25,11 +29,14 @@ std::tuple<QVariant, WId> extract_native_context(SDL_Window *window) {
 	if (SDL_GetWindowWMInfo(window, &wm_info)) {
 		NSWindow *ns_window = wm_info.info.cocoa.window;
 		view = [ns_window contentView];
+		assert(view);
+	
+		return std::make_tuple(QVariant::fromValue<QCocoaNativeContext>(QCocoaNativeContext(current_context)), [current_context] {
+			[current_context makeCurrentContext];
+		});
 	}
 
-	assert(view);
-
-	return std::make_tuple(QVariant::fromValue<QCocoaNativeContext>(QCocoaNativeContext(current_context)), reinterpret_cast<WId>(view));
+	return std::tuple<QVariant, std::function<void()>>{};
 }
 
 } // namespace qtsdl

--- a/libopenage/gui/guisys/private/platforms/context_extraction_x11.cpp
+++ b/libopenage/gui/guisys/private/platforms/context_extraction_x11.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 the openage authors. See copying.md for legal info.
+// Copyright 2015-2017 the openage authors. See copying.md for legal info.
 
 #include <cassert>
 
@@ -24,15 +24,38 @@ std::tuple<QVariant, WId> extract_native_context(SDL_Window *window) {
 
 		current_context = glXGetCurrentContext();
 		assert(current_context);
+
+		return std::make_tuple(
+			QVariant::fromValue<QGLXNativeContext>(
+				QGLXNativeContext(current_context,
+								  wm_info.info.x11.display,
+								  wm_info.info.x11.window)),
+			wm_info.info.x11.window
+		);
 	}
 
-	return std::make_tuple(
-		QVariant::fromValue<QGLXNativeContext>(
-			QGLXNativeContext(current_context,
-			                  wm_info.info.x11.display,
-			                  wm_info.info.x11.window)),
-		wm_info.info.x11.window
-	);
+	return std::tuple<QVariant, WId>{};
+}
+
+std::tuple<QVariant, std::function<void()>> extract_native_context_and_switchback_func(SDL_Window *window) {
+	assert(window);
+
+	GLXContext current_context;
+	SDL_SysWMinfo wm_info;
+	SDL_VERSION(&wm_info.version);
+
+	if (SDL_GetWindowWMInfo(window, &wm_info)) {
+		assert(wm_info.info.x11.display);
+
+		current_context = glXGetCurrentContext();
+		assert(current_context);
+
+		return std::make_tuple(QVariant::fromValue<QGLXNativeContext>(QGLXNativeContext(current_context, wm_info.info.x11.display, wm_info.info.x11.window)), [wm_info, current_context] {
+			glXMakeCurrent(wm_info.info.x11.display, wm_info.info.x11.window, current_context);
+		});
+	}
+
+	return std::tuple<QVariant, std::function<void()>>{};
 }
 
 } // namespace qtsdl


### PR DESCRIPTION
Apparently we [don't require the `glext.h` header on Mac](http://stackoverflow.com/a/27933440/5257399), but if that's the case, I am not sure why I get compile error:

```cpp
/Users/birch/git/openage/libopenage/gui/guisys/private/opengl_debug_logger.cpp:15:18: error: use of undeclared identifier
      'GL_DEBUG_CALLBACK_FUNCTION'
                        glGetPointerv(GL_DEBUG_CALLBACK_FUNCTION, &params.callback);
                                      ^
/Users/birch/git/openage/libopenage/gui/guisys/private/opengl_debug_logger.cpp:16:37: error: use of undeclared identifier
      'GL_DEBUG_OUTPUT_SYNCHRONOUS'
                        params.synchronous = glIsEnabled(GL_DEBUG_OUTPUT_SYNCHRONOUS);
                                                         ^
/Users/birch/git/openage/libopenage/gui/guisys/private/opengl_debug_logger.cpp:29:51: error: use of undeclared identifier
      'GL_DEBUG_TYPE_ERROR'
                        functions->glDebugMessageControl(GL_DONT_CARE, GL_DEBUG_TYPE_ERROR, GL_DONT_CARE, 0, nullptr, GL_TRUE);
                                                                       ^
/Users/birch/git/openage/libopenage/gui/guisys/private/opengl_debug_logger.cpp:30:51: error: use of undeclared identifier
      'GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR'
                        functions->glDebugMessageControl(GL_DONT_CARE, GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR, GL_DONT_CARE, 0, nullptr, GL_TRUE);
                                                                       ^
/Users/birch/git/openage/libopenage/gui/guisys/private/opengl_debug_logger.cpp:35:14: error: use of undeclared identifier
      'GL_DEBUG_OUTPUT_SYNCHRONOUS'
                                glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
```

Maybe we get everything except debug stuff?

I'm not sure that there is [KHR_debug support in Mac](http://renderingpipeline.com/2013/09/simulating-khr_debug-on-macos-x/). Apparently you'd need OpenGL 4.3.
Mac [only has OpenGL 4.1](https://support.apple.com/en-gb/HT202823).

I decided to throw in the missing `#define`s, to ensure that the code at least compiled.
The [license for `glext.h`](https://www.khronos.org/registry/OpenGL/api/GL/glext.h) seems pretty permissive, so hopefully this is fine.