### PR TITLE
Fix pixel transfer format

### DIFF
--- a/libopenage/texture.cpp
+++ b/libopenage/texture.cpp
@@ -85,12 +85,18 @@ void Texture::load() {
 	// glTexImage2D format determination
 	switch (surface->format->BytesPerPixel) {
 	case 3: // RGB 24 bit
-		this->buffer->texture_format_in  = GL_RGB8;
-		this->buffer->texture_format_out = GL_RGB;
+		this->buffer->texture_format_in = GL_RGB8;
+		this->buffer->texture_format_out
+		= surface->format->Rmask == 0x000000ff
+		? GL_RGB
+		: GL_BGR;
 		break;
 	case 4: // RGBA 32 bit
-		this->buffer->texture_format_in  = GL_RGBA8;
-		this->buffer->texture_format_out = GL_RGBA;
+		this->buffer->texture_format_in = GL_RGBA8;
+		this->buffer->texture_format_out
+		= surface->format->Rmask == 0x000000ff
+		? GL_RGBA
+		: GL_BGRA;
 		break;
 	default:
 		throw Error(MSG(err) <<


### PR DESCRIPTION
Fix pixel transfer format for loading an OpenGL texture from an SDL surface (i.e. swap red & blue channels on Mac)

Before:

![image](https://cloud.githubusercontent.com/assets/6141784/24840814/80e402c6-1d6c-11e7-9372-af94b8c4e183.png)

After:

![image](https://cloud.githubusercontent.com/assets/6141784/25029164/a847cb9c-20b2-11e7-93bf-5657d48ec13f.png)
